### PR TITLE
Add time to Twostep::checkCode

### DIFF
--- a/src/Abelorosz/Twostep/Twostep.php
+++ b/src/Abelorosz/Twostep/Twostep.php
@@ -18,11 +18,14 @@ class Twostep {
      *
      * @param 	int $code
      * @param 	string $secret
+     * @param 	timestamp $time
      * @return 	bool
      */
-    public function checkCode( $code, $secret )
+    public function checkCode( $code, $secret, $time = null  )
     {
-        $time = floor(time() / 30);
+        if (!$time)
+            $time = floor(time() / 30);
+
         for ( $i = -1; $i <= 1; $i++ )
             if ($this->getCode($secret,$time + $i) == $code)
                 return true;


### PR DESCRIPTION
When using an other given time in the method getCode, checkCode will always return false.
So when the given time can also be changed in checkCode, it will work fine again.